### PR TITLE
Rocket reservation & cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@
 ### Key Features <a name="key-features"></a>
 
 - **Nav Bar**
+- **Fetch Rockets & Display**
+- **Book and Cancel Rocket**
   
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -126,6 +128,11 @@ Example command:
 - GitHub: [@githubhandle](https://github.com/egichuhis)
 - Twitter: [@twitterhandle](https://twitter.com/egichuhis)
 - LinkedIn: [LinkedIn](https://www.linkedin.com/in/edwin-gichuhi/)
+
+👤 **Eric Mawudeku**
+
+- GitHub: [@githubhandle](https://github.com/erickma1)
+- LinkedIn: [LinkedIn](https://www.linkedin.com/in/eric-mawudeku-55b74883/)
 
 ## 🔭 Future Features <a name="future-features"></a>
 

--- a/src/components/Rockets/RocketCard.jsx
+++ b/src/components/Rockets/RocketCard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const RocketCard = ({ rocket }) => {
-  const { name, description, flickr_images: flickrImages } = rocket[0] || '';
+  const { name, description, flickr_images: flickrImages } = rocket || '';
 
   return (
     <div className="container py-4 py-xl-5">

--- a/src/components/Rockets/RocketCard.jsx
+++ b/src/components/Rockets/RocketCard.jsx
@@ -1,8 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { reserveRocket } from '../../redux/features/rocket/rocketSlice';
 
 const RocketCard = ({ rocket }) => {
-  const { name, description, flickr_images: flickrImages } = rocket || '';
+  const dispatch = useDispatch();
+
+  const {
+    id, name, description, flickr_images: flickrImages,
+  } = rocket || '';
+
+  const handleReserveRocket = (id) => {
+    dispatch(reserveRocket(id));
+  };
 
   return (
     <div className="container py-4 py-xl-5">
@@ -24,7 +34,11 @@ const RocketCard = ({ rocket }) => {
               <p className="card-text">
                 {description}
               </p>
-              <button className="btn btn-primary" type="button">
+              <button
+                onClick={() => handleReserveRocket(id)}
+                className="btn btn-primary"
+                type="button"
+              >
                 Reserve Rocket
               </button>
             </div>

--- a/src/components/Rockets/RocketCard.jsx
+++ b/src/components/Rockets/RocketCard.jsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { reserveRocket } from '../../redux/features/rocket/rocketSlice';
+import { reserveRocket, cancelReservation } from '../../redux/features/rocket/rocketSlice';
 
 const RocketCard = ({ rocket }) => {
   const dispatch = useDispatch();
 
   const {
-    id, name, description, flickr_images: flickrImages,
+    id, name, description, flickr_images: flickrImages, reserved,
   } = rocket || '';
 
   const handleReserveRocket = (id) => {
     dispatch(reserveRocket(id));
+  };
+
+  const handleCancelReservation = (id) => {
+    dispatch(cancelReservation(id));
   };
 
   return (
@@ -34,13 +38,24 @@ const RocketCard = ({ rocket }) => {
               <p className="card-text">
                 {description}
               </p>
-              <button
-                onClick={() => handleReserveRocket(id)}
-                className="btn btn-primary"
-                type="button"
-              >
-                Reserve Rocket
-              </button>
+              {reserved ? (
+                <button
+                  onClick={() => handleCancelReservation(id)}
+                  className="btn btn-outline-secondary"
+                  type="button"
+                >
+                  Cancel Reservation
+                </button>
+              ) : (
+                <button
+                  onClick={() => handleReserveRocket(id)}
+                  className="btn btn-primary"
+                  type="button"
+                >
+                  Reserve Rocket
+                </button>
+              )}
+
             </div>
           </div>
         </div>
@@ -55,6 +70,7 @@ RocketCard.propTypes = {
     name: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     flickrImages: PropTypes.string.isRequired,
+    reserved: PropTypes.bool.isRequired,
   }).isRequired,
 };
 

--- a/src/components/Rockets/RocketsList.jsx
+++ b/src/components/Rockets/RocketsList.jsx
@@ -11,8 +11,7 @@ const RocketsList = () => {
     dispatch(fetchRockets());
   }, [dispatch]);
 
-  const rockets = myRockets[1];
-  console.log('carnivore_rockets', rockets);
+  const rockets = Array.isArray(myRockets) ? myRockets : [];
 
   return (
     <div>

--- a/src/components/Rockets/RocketsList.jsx
+++ b/src/components/Rockets/RocketsList.jsx
@@ -11,9 +11,12 @@ const RocketsList = () => {
     dispatch(fetchRockets());
   }, [dispatch]);
 
+  const rockets = myRockets[1];
+  console.log('carnivore_rockets', rockets);
+
   return (
     <div>
-      {myRockets.map((rocket) => (
+      {rockets.map((rocket) => (
         <ul key={rocket.id} className="list-unstyled">
           <li>
             <RocketCard rocket={rocket} />

--- a/src/redux/features/rocket/rocketSlice.js
+++ b/src/redux/features/rocket/rocketSlice.js
@@ -29,7 +29,7 @@ export const rocketSlice = createSlice(
       });
       builder.addCase(fetchRockets.fulfilled, (state, action) => {
         state.loading = false;
-        state.rockets = Object.values(action);
+        state.rockets = action.payload;
         state.error = '';
       });
       builder.addCase(fetchRockets.rejected, (state, action) => {

--- a/src/redux/features/rocket/rocketSlice.js
+++ b/src/redux/features/rocket/rocketSlice.js
@@ -9,7 +9,14 @@ const initialState = {
 
 export const fetchRockets = createAsyncThunk('rocket/fetchRockets', async () => {
   const response = await axios.get('https://api.spacexdata.com/v4/rockets');
-  return response.data;
+  const rocketsData = response.data.map((rocket) => ({
+    id: rocket.id,
+    name: rocket.name,
+    description: rocket.description,
+    flickr_images: rocket.flickr_images,
+    reserved: false,
+  }));
+  return rocketsData;
 });
 
 export const rocketSlice = createSlice(
@@ -21,6 +28,12 @@ export const rocketSlice = createSlice(
         state.rockets = state.map((rocket) => {
           if (rocket.id !== action.payload) return rocket;
           return { ...rocket, reserved: true };
+        });
+      },
+      cancelReservation: (state, action) => {
+        state.rockets = state.map((rocket) => {
+          if (rocket.id !== action.payload) return rocket;
+          return { ...rocket, reserved: false };
         });
       },
     },
@@ -42,6 +55,6 @@ export const rocketSlice = createSlice(
   },
 );
 
-export const { reserveRocket } = rocketSlice.actions;
+export const { reserveRocket, cancelReservation } = rocketSlice.actions;
 
 export default rocketSlice.reducer;

--- a/src/redux/features/rocket/rocketSlice.js
+++ b/src/redux/features/rocket/rocketSlice.js
@@ -25,13 +25,13 @@ export const rocketSlice = createSlice(
     initialState,
     reducers: {
       reserveRocket: (state, action) => {
-        state.rockets = state.map((rocket) => {
+        state.rockets = state.rockets.map((rocket) => {
           if (rocket.id !== action.payload) return rocket;
           return { ...rocket, reserved: true };
         });
       },
       cancelReservation: (state, action) => {
-        state.rockets = state.map((rocket) => {
+        state.rockets = state.rockets.map((rocket) => {
           if (rocket.id !== action.payload) return rocket;
           return { ...rocket, reserved: false };
         });

--- a/src/redux/features/rocket/rocketSlice.js
+++ b/src/redux/features/rocket/rocketSlice.js
@@ -17,10 +17,11 @@ export const rocketSlice = createSlice(
     name: 'rocket',
     initialState,
     reducers: {
-      removeRocket: (state, action) => {
-        state.rockets = state.rockets.filter(
-          (book) => book.itemId !== action.payload,
-        );
+      reserveRocket: (state, action) => {
+        state.rockets = state.map((rocket) => {
+          if (rocket.id !== action.payload) return rocket;
+          return { ...rocket, reserved: true };
+        });
       },
     },
     extraReducers: (builder) => {
@@ -40,5 +41,7 @@ export const rocketSlice = createSlice(
     },
   },
 );
+
+export const { reserveRocket } = rocketSlice.actions;
 
 export default rocketSlice.reducer;


### PR DESCRIPTION
Hello, please review this PR.

Changes made:
- Write actions and reducers for booking rockets/dragons and joining missions
- Rockets that have already been reserved should show a "Reserved" badge and a "Cancel reservation" button instead of the default "Reserve rocket" (as per design).
- Rockets/Dragons and Missions should use the React conditional rendering syntax
- When a user clicks the "Reserve rocket" button, an action is dispatched to update the store. We get the ID of the reserved rocket and update the state.
